### PR TITLE
+ SB: Allow exodus conversions in the new c++ style print/println/for…

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,18 +12,18 @@ jobs:
     strategy:
       matrix:
         include:
-#          # Specific one
-#          - UBUNTU_VER: "22.04"
-#            PG_VER:
-#            COMPILER:
+          # Specific one
+          - UBUNTU_VER: "22.04"
+            PG_VER:
+            COMPILER:
 #          # Specific one
 #          - UBUNTU_VER: "20.04"
 #            PG_VER:
 #            COMPILER:
-          # Specific one
-          - UBUNTU_VER: "22.04"
-            PG_VER:
-            COMPILER: clang
+#          # Specific one
+#          - UBUNTU_VER: "22.04"
+#            PG_VER:
+#            COMPILER: clang
 #          # Specific one
 #          - UBUNTU_VER: "20.04"
 #            PG_VER:

--- a/exodus/libexodus/exodus/exofuncs.h
+++ b/exodus/libexodus/exodus/exofuncs.h
@@ -793,6 +793,21 @@ struct fmt::formatter<exodus::var> {
 	auto format(const exodus::var& v1, FormatContext& ctx) const {
 		//std::cout << "c1:'" << c1 << " c2:'" << c2 << "' c3:'" << c3 << "' c4:'" << c4 << "' \n";
 		//std::cout << "fmtstr:'" << fmt_str << "' fmtcode:'" << formatcode << "' \n";
+
+		// 1. EXODUS conversions
+		// Unfortunately without time zone or number format currently.
+		// TODO allow thread_local global timezone, number format?
+		// {::MD20PZ}
+		// {::D2/E} etc.
+		// {::MTHS} etc.
+		if (fmt_str[2] == ':') {
+			//ctx.out() << v1.oconv(fmt_str.data());
+			auto conversion = std::string(fmt_str.begin() + 3, fmt_str.end() - 1);
+			return vformat_to(ctx.out(), "{:}", make_format_args(v1.oconv(conversion.data()).toString()));
+		}
+
+		else
+		// 2. C++ style format codes
 		switch (formatcode) {
 
 			// Floating point

--- a/install.sh
+++ b/install.sh
@@ -56,9 +56,10 @@ set -euxo pipefail
 : Update apt
 : ----------
 :
-	if ! ls /var/cache/apt/*.bin &>/dev/null; then
-		sudo apt -y update
-	fi
+	ls -l /var/cache/apt/ || true
+	while ! ls /var/cache/apt/*.bin && ! sudo apt -y update; do
+		sleep 1
+	done
 :
 : ------------------------
 : Work out postgres suffix

--- a/service/create_site
+++ b/service/create_site
@@ -122,7 +122,7 @@ set -euxo pipefail
 : Link to exodus www
 : ==================
 :
-	rm $SITEDIR/www || true
+	rm $SITEDIR/www -rf
 	ln -snf ~/exodus/service/www/ $SITEDIR/www
 
 :

--- a/test/src/test_format.cpp
+++ b/test/src/test_format.cpp
@@ -9,6 +9,32 @@ function main() {
 
 #ifdef EXO_FORMAT
 
+	{
+		// Various exodus conversions using the {::XXXXXX} pattern
+
+		assert(format("{::MD20}", var(123.456)).outputl() == "123.46");
+		assert(format("{::MD20}", var(123456)).outputl() == "123456.00");
+		// P has no effect if both number of decimals (2) and number to move (0) are specified
+		assert(format("{::MD20P}", var(123.456)).outputl() == "123.46");
+		assert(format("{::MD20P}", var(123456)).outputl() == "123456.00");
+
+		// P = Preserve decimal point position
+
+		// A single 2 means MOVE the decimal place left by two AND show 2 decimal places
+		assert(format("{::MD2}", var(123.456)).outputl() == "1.23");
+		assert(format("{::MD2}", var(123456)).outputl() == "1234.56");
+
+		// P means "if a decimal point is found then do not move the decimal point"
+		// otherwise a single 2 means MOVE the decimal point left by 2 AND use use two decimal places
+		assert(format("{::MD2P}", var(123.456)).outputl() == "123.46");
+		assert(format("{::MD2P}", var(123456)).outputl() == "123456.00");
+
+
+		assert(format("{::MTS}", var(60*60*12 + 1)) == "12:00:01");
+
+		assert(format("{::D4/E}", var(20000)) == "03/10/2022");
+	}
+
 	assert(format("{:9.1f}", 123.456) == "    123.5");
 	assert(format("{:9.1f}", -123.456) == "   -123.5");
 //	assert(std::format("{:9.1f}", var(123.456)) == "    123.5");


### PR DESCRIPTION
…mat functions in the style of {::MD20PZ} {::D2/E} {::MTS} etc. Unfortunately without time zone or number format currently. TODO allow thread_local global timezone, number format?