### PR TITLE
~ SB: Remove various warnings from clang especially related to adding…

### DIFF
--- a/cli/src/compile.cpp
+++ b/cli/src/compile.cpp
@@ -306,11 +306,8 @@ function main() {
 
 		}
 
-//		if (not warnings) {
-//			basicoptions ^= " -Wno-extra-semi-stmt";
-//			basicoptions ^= " -Wno-newline-eof";
-//		}
 		if (warnings > 0) {
+
 			if (clang)
 				basicoptions ^= " -Weverything ";
 			else {
@@ -319,17 +316,24 @@ function main() {
 				basicoptions ^= " -Wno-unknown-pragmas ";
 			}
 
+			// Show these warnings at any level > 0
+			//if (warnings < 0) {
+			//	basicoptions ^= " -Wno-extra-semi-stmt";
+			//	basicoptions ^= " -Wno-newline-eof";
+			//}
+
 			// The following warnings will only appear at level 2 or greater
 			if (warnings < 2) {
 				basicoptions ^= " -Wno-shadow";
 				basicoptions ^= " -Wno-unreachable-code";
+				basicoptions ^= " -Wno-unreachable-code-return";
 				basicoptions ^= " -Wno-unused-macros";
-				if (clang) {
+				basicoptions ^= " -Wno-missing-noreturn";
+				//if (clang) {
 					basicoptions ^= " -Wno-unreachable-code-return";
 					// use of GNU ?: conditional expression extension, omitting middle operand
 					basicoptions ^= " -Wno-gnu-conditional-omitted-operand";
-				}
-				basicoptions ^= " -Wno-padded";
+				//}
 			}
 
 			if (warnings < 3) {
@@ -337,7 +341,7 @@ function main() {
 			}
 
 			// The following warnings will only appear at level 3 or greater
-			if (warnings > 3) {
+			if (warnings >= 3) {
 				//basicoptions ^= " -Wno-missing-prototypes";
 				//basicoptions ^= " -Wno-weak-vtables";
 				basicoptions ^= " -Wpedantic";// Disallows "Elvis operator" ?:

--- a/cli/src/syncdat.cpp
+++ b/cli/src/syncdat.cpp
@@ -177,7 +177,7 @@ function main() {
 
 		}
 
-		var newcpptext = "#include <exodus/library.h>\n";
+		var newcpptext = "#include <exodus/library.h>\n\n";
 		var dict2sql_ids = "";
 
 		// Process each dat file/record in the subdir

--- a/exodus/libexodus/exodus/common.h
+++ b/exodus/libexodus/exodus/common.h
@@ -10,16 +10,6 @@
 // An xxx_common.h file may have multiple commoninit/exit sections.
 //
 
-// Why is this needed here? It is needed in program.h library.h.
-#undef subroutine
-#undef function
-#define subroutine \
- public:           \
-	void
-#define function   \
- public:           \
-	var
-
 ////////////////////////////////////////
 // Open a class derived from NamedCommon
 ////////////////////////////////////////

--- a/exodus/libexodus/exodus/exomacros.h
+++ b/exodus/libexodus/exodus/exomacros.h
@@ -63,9 +63,12 @@ THE SOFTWARE.
 // ===========================
 // Allow simplified syntax eg "function xyz(in arg1, out arg2) { ..."
 //
+#undef function
+#undef subroutine
+#undef subroutine_noreturn
+#define function public: var
 #define subroutine public: void
-#define function   public: var
-
+#define subroutine_noreturn public: [[noreturn]] void
 
 // "Call" and "Gosub"
 // ==================

--- a/exodus/libexodus/exodus/program.h
+++ b/exodus/libexodus/exodus/program.h
@@ -20,16 +20,12 @@
 // argument. Additional matching pairs of statements can delineate additional subprograms as long
 // as each pair has a unique argument since their argument names are used as part of the class name.
 
-#undef subroutine
-#undef function
-
-#define subroutine \
-   public:         \
-	void
-
-#define function \
-   public:       \
-	var
+//#undef function
+//#undef subroutine
+//#undef subroutine_noreturn
+//#define function public: var
+//#define subroutine public: void
+//#define subroutine_noreturn public: [[noreturn]] void
 
 // SIMILAR CODE IN
 // program.h library.h

--- a/service/src/exo/floatspeed.cpp
+++ b/service/src/exo/floatspeed.cpp
@@ -61,10 +61,8 @@ function main() {
 
 	call mssg(msg);
 
-	// call restorescreenss1, ss2);
-	stop();
 
-	return "";
+	return 0;
 }
 
 subroutine getspeed(io retval) {

--- a/service/src/exo/get.cpp
+++ b/service/src/exo/get.cpp
@@ -112,8 +112,6 @@ nooutput:
 	// dfs=dfs2
 	// end
 
-	stop();
-	// for c++
 	return 0;
 }
 

--- a/service/src/exo/memspeed.cpp
+++ b/service/src/exo/memspeed.cpp
@@ -58,10 +58,7 @@ function main() {
 
 	call mssg(msg);
 
-	// call restorescreenss1, ss2);
-	stop();
-
-	return "";
+	return 0;
 }
 
 subroutine getspeed(io retval) {

--- a/service/src/exo/procspeed.cpp
+++ b/service/src/exo/procspeed.cpp
@@ -61,10 +61,8 @@ function main() {
 
 	call mssg(msg);
 
-	// call restorescreenss1, ss2);
-	stop();
+	return 0;
 
-	return "";
 }
 
 subroutine getspeed(io retval) {

--- a/service/src/exo/serve_exo.cpp
+++ b/service/src/exo/serve_exo.cpp
@@ -14,9 +14,12 @@ programinit()
 function main() {
 
 	// NB numbers and names MUST match those in the matching common .h files
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunsafe-buffer-usage"
 	mv.namedcommon[req_common_no] = new req_common;
 	mv.namedcommon[srv_common_no] = new srv_common;
 	// mv.namedcommon[agy_common_no]=new agy_common;
+#pragma GCC diagnostic pop
 
 	/*cat ~/pickos/dic/ *.SQL | psql -h 127.0.0.1 -U exodus exodus*/
 

--- a/service/src/srv/about.cpp
+++ b/service/src/srv/about.cpp
@@ -73,8 +73,6 @@ function main() {
 
 	call note(text);
 
-	stop();
-
 	return 0;
 }
 

--- a/service/src/srv/autorun.cpp
+++ b/service/src/srv/autorun.cpp
@@ -40,9 +40,6 @@ function main() {
 
 	call autorun3(docids, options);
 
-	stop();
-
-	// only for c++
 	return 0;
 }
 

--- a/service/src/srv/builddict.cpp
+++ b/service/src/srv/builddict.cpp
@@ -83,7 +83,6 @@ function main() {
 
 	stop();
 
-	return "";
 }
 
 subroutine definemacro() {

--- a/service/src/srv/clearfield.cpp
+++ b/service/src/srv/clearfield.cpp
@@ -164,9 +164,8 @@ next:
 exit:
 	// ///
 	gosub flush(filename);
-	stop();
 
-	return "";
+	return 0;
 }
 
 subroutine flush(in filename) {

--- a/service/src/srv/crosstab.cpp
+++ b/service/src/srv/crosstab.cpp
@@ -311,6 +311,7 @@ nextmv:
 		if (not allrowvals.f(1).locateby("AL", rowval, rown)) {
 			if (allrowvals.len() + rowval.len() > 65000) {
 				gosub abort_toobig(filename);
+				//std::unreachable()
 			}
 			nrows += 1;
 			allrowvals.inserter(1, rown, rowval);
@@ -325,11 +326,13 @@ nextmv:
 				ncols += 1;
 				if (allcolvals.len() + colval.len() > 65000) {
 					gosub abort_toobig(filename);
+					//std::unreachable()
 				}
 				allcolvals.inserter(1, colnx, colval);
 
 				if (output.len() + nrows * 2 > 65000) {
 					gosub abort_toobig(filename);
+					//std::unreachable()
 				}
 
 				output.inserter(1, 1 + colnx, colval);
@@ -340,6 +343,7 @@ nextmv:
 
 			if (output.len() + datavals.len() > 6500) {
 				gosub abort_toobig(filename);
+				//std::unreachable()
 			}
 
 			oldval = output.f(rown + 1, colnx + 1);
@@ -391,6 +395,7 @@ exit:
 	for (const int rown : range(1, nrows)) {
 		if (output.len() + allrowvals.len() > 65000) {
 			gosub abort_toobig(filename);
+			//std::unreachable()
 		}
 		output(rown + 1, 1) = allrowvals.f(1, rown);
 	}  // rown;
@@ -416,7 +421,7 @@ exit:
 	return 0;
 }
 
-subroutine abort_toobig(in filename) {
+subroutine_noreturn abort_toobig(in filename) {
 
 	clearselect();
 	msg = "Crosstab too complex. Please simplify your request.";

--- a/service/src/srv/initgeneral.cpp
+++ b/service/src/srv/initgeneral.cpp
@@ -322,8 +322,8 @@ function main() {
 badversion:
 					msg_ = msg;
 					gosub failsys();
-					stop();
-
+					//stop();
+					//std::unreachable()
 				} else {
 decideversion:
 					var options = "Quit (RECOMMENDED)";
@@ -523,7 +523,8 @@ nextreport:
 			call log2("*if sysmode then respond to response file and close", logtime);
 			if (SYSTEM.f(33)) {
 				gosub failsys();
-				stop();
+				//stop();
+				//std::unreachable();
 			}
 
 			call log2("*inform user and close", logtime);
@@ -542,9 +543,12 @@ nextreport:
 			call note(msg);
 			if (SYSTEM.f(33)) {
 				gosub failsys();
+				//stop();
+				//std::unreachable();
 			}
 			perform("OFF");
 			logoff();
+			//std::unreachable();
 		}
 	}
 
@@ -1501,7 +1505,8 @@ adddatasetcodename:
 		if (not datasetid.f(4).locate(cid())) {
 			msg_ = var("CANNOT USE THIS DATABASE ON THIS COMPUTER").quote();
 			gosub failsys();
-			stop();
+			//stop();
+			//std::unreachable();
 		}
 	}
 
@@ -1706,7 +1711,6 @@ adddatasetcodename:
 	}
 
 	stop();
-	return 0;
 }
 
 subroutine getsystem(in config_osfilename, in confign) {
@@ -1739,7 +1743,7 @@ subroutine getsystem(in config_osfilename, in confign) {
 	return;
 }
 
-subroutine failsys() {
+subroutine_noreturn failsys() {
 	var msgx = msg_;
 
 	var msg2 = "*Authorisation Failure. " ^ msgx;
@@ -1764,7 +1768,8 @@ subroutine failsys() {
 	perform("OFF");
 	logoff();
 
-	return;
+	//return;
+	//std::unreachable();
 }
 
 libraryexit()

--- a/service/src/srv/listen.cpp
+++ b/service/src/srv/listen.cpp
@@ -239,8 +239,6 @@ function main() {
 
 	stop();
 
-	// never gets here
-	return 0;
 }
 
 function main_init() {

--- a/service/src/srv/liststats.cpp
+++ b/service/src/srv/liststats.cpp
@@ -261,8 +261,6 @@ function main() {
 	}
 
 	stop();
-
-	return 0;
 }
 
 libraryexit()

--- a/service/src/srv/select2.cpp
+++ b/service/src/srv/select2.cpp
@@ -431,7 +431,6 @@ nextrec:
 			// abort
 			gosub exit();
 			stop();
-			return 0;
 		}
 	}  // limitfieldn;
 


### PR DESCRIPTION
… [[noreturn]] to various functions that dont return like var::stop() etc.